### PR TITLE
Restore upbge physics UI

### DIFF
--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -26,15 +26,15 @@ class PhysicsButtonsPanel:
     bl_region_type = 'WINDOW'
     bl_context = "physics"
 
-
 class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
     bl_label = "Physics"
-    COMPAT_ENGINES = {'BLENDER_GAME', 'BLENDER_EEVEE'}
+    COMPAT_ENGINES = {'BLENDER_EEVEE'}
 
     @classmethod
     def poll(cls, context):
         ob = context.active_object
-        return ob and ob.game and (context.scene.render.engine in cls.COMPAT_ENGINES)
+        rd = context.scene.render
+        return ob and ob.game and (rd.engine in cls.COMPAT_ENGINES)
 
     def draw(self, context):
         layout = self.layout
@@ -51,10 +51,18 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
         if physics_type == 'CHARACTER':
             layout.prop(game, "use_actor")
             layout.prop(ob, "hide_render", text="Invisible")  # out of place but useful
-            layout.prop(game, "step_height", slider=True)
-            layout.prop(game, "jump_speed")
-            layout.prop(game, "fall_speed")
-            layout.prop(game, "jump_max")
+
+            layout.separator()
+
+            split = layout.split()
+
+            col = split.column()
+            col.prop(game, "step_height", slider=True)
+            col.prop(game, "fall_speed")
+            col.prop(game, "max_slope")
+            col = split.column()
+            col.prop(game, "jump_speed")
+            col.prop(game, "jump_max")
 
         elif physics_type in {'DYNAMIC', 'RIGID_BODY'}:
             split = layout.split()
@@ -65,7 +73,7 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
             col.prop(ob, "hide_render", text="Invisible")  # out of place but useful
 
             col = split.column()
-            col.prop(game, "use_material_physics_fh")
+            col.prop(game, "use_physics_fh")
             col.prop(game, "use_rotate_from_normal")
             col.prop(game, "use_sleep")
 
@@ -78,8 +86,19 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
             col.prop(game, "mass")
             col.prop(game, "radius")
             col.prop(game, "form_factor")
+            col.prop(game, "elasticity", slider=True)
+
+            col.label(text="Linear Velocity:")
+            sub = col.column(align=True)
+            sub.prop(game, "velocity_min", text="Minimum")
+            sub.prop(game, "velocity_max", text="Maximum")
 
             col = split.column()
+            col.label(text="Friction:")
+            col.prop(game, "friction")
+            col.prop(game, "rolling_friction")
+            col.separator()
+
             sub = col.column()
             sub.prop(game, "use_anisotropic_friction")
             subsub = sub.column()
@@ -87,13 +106,8 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
             subsub.prop(game, "friction_coefficients", text="", slider=True)
 
             split = layout.split()
-
             col = split.column()
-            col.label(text="Linear Velocity:")
-            sub = col.column(align=True)
-            sub.prop(game, "velocity_min", text="Minimum")
-            sub.prop(game, "velocity_max", text="Maximum")
-            col.label(text="Angular Velocity:")
+            col.label(text="Angular velocity:")
             sub = col.column(align=True)
             sub.prop(game, "angular_velocity_min", text="Minimum")
             sub.prop(game, "angular_velocity_max", text="Maximum")
@@ -106,20 +120,22 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
 
             layout.separator()
 
-            split = layout.split()
+            col = layout.column()
 
-            col = split.column()
             col.label(text="Lock Translation:")
-            col.prop(game, "lock_location_x", text="X")
-            col.prop(game, "lock_location_y", text="Y")
-            col.prop(game, "lock_location_z", text="Z")
+            row = col.row()
+            row.prop(game, "lock_location_x", text="X")
+            row.prop(game, "lock_location_y", text="Y")
+            row.prop(game, "lock_location_z", text="Z")
 
         if physics_type == 'RIGID_BODY':
-            col = split.column()
+            col = layout.column()
+
             col.label(text="Lock Rotation:")
-            col.prop(game, "lock_rotation_x", text="X")
-            col.prop(game, "lock_rotation_y", text="Y")
-            col.prop(game, "lock_rotation_z", text="Z")
+            row = col.row()
+            row.prop(game, "lock_rotation_x", text="X")
+            row.prop(game, "lock_rotation_y", text="Y")
+            row.prop(game, "lock_rotation_z", text="Z")
 
         elif physics_type == 'SOFT_BODY':
             col = layout.column()
@@ -132,23 +148,39 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
             split = layout.split()
 
             col = split.column()
-            col.label(text="Attributes:")
+            col.label(text="General Attributes:")
             col.prop(game, "mass")
             # disabled in the code
             # col.prop(soft, "weld_threshold")
-            col.prop(soft, "location_iterations")
             col.prop(soft, "linear_stiffness", slider=True)
             col.prop(soft, "dynamic_friction", slider=True)
+            col.prop(soft, "kdp", text="Damping", slider=True)
             col.prop(soft, "collision_margin", slider=True)
+            col.prop(soft, "kvcf", text="Velocity Correction", slider=True)
             col.prop(soft, "use_bending_constraints", text="Bending Constraints")
 
-            col = split.column()
+            sub = col.column()
+            sub.active = soft.use_bending_constraints
+            #sub.prop(soft, "bending_distance") #TODO: missing in UPBGE -> fix in UPBGE
+
             col.prop(soft, "use_shape_match")
+
             sub = col.column()
             sub.active = soft.use_shape_match
             sub.prop(soft, "shape_threshold", slider=True)
 
-            col.separator()
+            col.label(text="Solver Iterations:")
+            col.prop(soft, "position_solver_iterations", text="Position Solver")
+            col.prop(soft, "velocity_solver_iterations", text="Velocity Solver")
+            col.prop(soft, "cluster_solver_iterations", text="Cluster Solver")
+            col.prop(soft, "drift_solver_iterations", text="Drift Solver")
+
+            col = split.column()
+            col.label(text="Hardness:")
+            col.prop(soft, "kchr", text="Rigid Contacts", slider=True)
+            col.prop(soft, "kkhr", text="Kinetic Contacts", slider=True)
+            col.prop(soft, "kshr", text="Soft Contacts", slider=True)
+            col.prop(soft, "kahr", text="Anchors", slider=True)
 
             col.label(text="Cluster Collision:")
             col.prop(soft, "use_cluster_rigid_to_softbody")
@@ -156,12 +188,29 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
             sub = col.column()
             sub.active = (soft.use_cluster_rigid_to_softbody or soft.use_cluster_soft_to_softbody)
             sub.prop(soft, "cluster_iterations", text="Iterations")
+            sub.prop(soft, "ksrhr_cl", text="Rigid Hardness", slider=True)
+            sub.prop(soft, "kskhr_cl", text="Kinetic Hardness", slider=True)
+            sub.prop(soft, "ksshr_cl", text="Soft Hardness", slider=True)
+            sub.prop(soft, "ksr_split_cl", text="Rigid Impulse Split", slider=True)
+            sub.prop(soft, "ksk_split_cl", text="Kinetic Impulse Split", slider=True)
+            sub.prop(soft, "kss_split_cl", text="Soft Impulse Split", slider=True)
+
+            split = layout.split()
+
+            col = split.column()
+            col.label(text="Volume:")
+            col.prop(soft, "kpr", text="Pressure Coefficient")
+            col.prop(soft, "kvc", text="Volume Conservation")
+
+            col = split.column()
+            col.label(text="Aerodynamics:")
+            col.prop(soft, "kdg", text="Drag Coefficient")
+            col.prop(soft, "klf", text="Lift Coefficient")
 
         elif physics_type == 'STATIC':
             col = layout.column()
             col.prop(game, "use_actor")
             col.prop(game, "use_ghost")
-            col.prop(game, "use_record_animation")
             col.prop(ob, "hide_render", text="Invisible")
 
             layout.separator()
@@ -171,6 +220,10 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
             col = split.column()
             col.label(text="Attributes:")
             col.prop(game, "radius")
+            col.prop(game, "elasticity", slider=True)
+            col.label(text="Friction:")
+            col.prop(game, "friction")
+            col.prop(game, "rolling_friction")
 
             col = split.column()
             sub = col.column()
@@ -196,16 +249,29 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
             layout.operator("mesh.navmesh_reset")
             layout.operator("mesh.navmesh_clear")
 
+        if physics_type in {"STATIC", "DYNAMIC", "RIGID_BODY"}:
+            row = layout.row()
+            row.label(text="Force Field:")
+
+            row = layout.row()
+            row.prop(game, "fh_force")
+            row.prop(game, "fh_damping", slider=True)
+
+            row = layout.row()
+            row.prop(game, "fh_distance")
+            row.prop(game, "use_fh_normal")
+
 
 class PHYSICS_PT_game_collision_bounds(PhysicsButtonsPanel, Panel):
     bl_label = "Collision Bounds"
-    COMPAT_ENGINES = {'BLENDER_GAME', 'BLENDER_EEVEE'}
+    COMPAT_ENGINES = {'BLENDER_EEVEE'}
 
     @classmethod
     def poll(cls, context):
         game = context.object.game
-        return (context.scene.render.engine in cls.COMPAT_ENGINES) \
-                and (game.physics_type in {'SENSOR', 'STATIC', 'DYNAMIC', 'RIGID_BODY', 'CHARACTER', 'SOFT_BODY'})
+        rd = context.scene.render
+        return (rd.engine in cls.COMPAT_ENGINES) \
+            and (game.physics_type in {'SENSOR', 'STATIC', 'DYNAMIC', 'RIGID_BODY', 'CHARACTER', 'SOFT_BODY'})
 
     def draw_header(self, context):
         game = context.active_object.game
@@ -239,13 +305,14 @@ class PHYSICS_PT_game_collision_bounds(PhysicsButtonsPanel, Panel):
 
 class PHYSICS_PT_game_obstacles(PhysicsButtonsPanel, Panel):
     bl_label = "Create Obstacle"
-    COMPAT_ENGINES = {'BLENDER_GAME', 'BLENDER_EEVEE'}
+    COMPAT_ENGINES = {'BLENDER_EEVEE'}
 
     @classmethod
     def poll(cls, context):
         game = context.object.game
-        return (context.scene.render.engine in cls.COMPAT_ENGINES) \
-                and (game.physics_type in {'SENSOR', 'STATIC', 'DYNAMIC', 'RIGID_BODY', 'SOFT_BODY', 'CHARACTER', 'NO_COLLISION'})
+        rd = context.scene.render
+        return (rd.engine in cls.COMPAT_ENGINES) \
+            and (game.physics_type in {'SENSOR', 'STATIC', 'DYNAMIC', 'RIGID_BODY', 'SOFT_BODY', 'CHARACTER', 'NO_COLLISION'})
 
     def draw_header(self, context):
         game = context.active_object.game
@@ -262,6 +329,7 @@ class PHYSICS_PT_game_obstacles(PhysicsButtonsPanel, Panel):
         row = layout.row()
         row.prop(game, "obstacle_radius", text="Radius")
         row.label()
+
 
 
 class RenderButtonsPanel:

--- a/source/blender/makesdna/DNA_object_types.h
+++ b/source/blender/makesdna/DNA_object_types.h
@@ -123,6 +123,21 @@ typedef struct LodLevel {
 	int obhysteresis;
 } LodLevel;
 
+typedef struct ObjectActivityCulling {
+	/* For game engine, values around active camera where physics or logic are suspended */
+	float physicsRadius;
+	float logicRadius;
+
+	int flags;
+	int pad;
+} ObjectActivityCulling;
+
+/* object activity flags */
+enum {
+	OB_ACTIVITY_PHYSICS = (1 << 0),
+	OB_ACTIVITY_LOGIC = (1 << 1),
+};
+
 typedef struct ObjectDisplay {
 	int flag;
 } ObjectDisplay;
@@ -279,8 +294,10 @@ typedef struct Object {
 	float step_height;
 	float jump_speed;
 	float fall_speed;
+	float max_slope;
+	int pad55;
 	unsigned char max_jumps;
-	char pad2;
+	char pad2[3];
 
 	/* Depsgraph */
 	short base_flag; /* used by depsgraph, flushed from base */
@@ -297,7 +314,7 @@ typedef struct Object {
 	short dtx;			/* viewport draw extra settings */
 	char dt;			/* viewport draw type */
 	char empty_drawtype;
-	char pad52[6];
+	char pad52[4];
 	float empty_drawsize;
 	float dupfacesca;	/* dupliface scale */
 	
@@ -305,6 +322,8 @@ typedef struct Object {
 	ListBase sensors;		/* game logic sensors */
 	ListBase controllers;	/* game logic controllers */
 	ListBase actuators;		/* game logic actuators */
+
+	struct ObjectActivityCulling activityCulling;
 
 	float sf; /* sf is time-offset */
 
@@ -378,6 +397,8 @@ typedef struct Object {
 	/* Object Display */
 	struct ObjectDisplay display;
 	int pad9;
+
+	struct Mesh *gamePredefinedBound;
 } Object;
 
 /* Warning, this is not used anymore because hooks are now modifiers */

--- a/source/blender/makesrna/intern/rna_object_force.c
+++ b/source/blender/makesrna/intern/rna_object_force.c
@@ -1488,65 +1488,159 @@ static void rna_def_game_softbody(BlenderRNA *brna)
 	srna = RNA_def_struct(brna, "GameSoftBodySettings", NULL);
 	RNA_def_struct_sdna(srna, "BulletSoftBody");
 	RNA_def_struct_ui_text(srna, "Game Soft Body Settings",
-	                       "Soft body simulation settings for an object in the game engine");
-	
+		"Soft body simulation settings for an object in the game engine");
+
 	/* Floats */
-	
+
 	prop = RNA_def_property(srna, "linear_stiffness", PROP_FLOAT, PROP_NONE);
 	RNA_def_property_float_sdna(prop, NULL, "linStiff");
 	RNA_def_property_range(prop, 0.0f, 1.0f);
 	RNA_def_property_ui_text(prop, "Linear Stiffness", "Linear stiffness of the soft body links");
-	
+
 	prop = RNA_def_property(srna, "dynamic_friction", PROP_FLOAT, PROP_NONE);
 	RNA_def_property_float_sdna(prop, NULL, "kDF");
 	RNA_def_property_range(prop, 0.0f, 1.0f);
 	RNA_def_property_ui_text(prop, "Friction", "Dynamic Friction");
-	
+
 	prop = RNA_def_property(srna, "shape_threshold", PROP_FLOAT, PROP_NONE);
 	RNA_def_property_float_sdna(prop, NULL, "kMT");
 	RNA_def_property_range(prop, 0.0f, 1.0f);
 	RNA_def_property_ui_text(prop, "Threshold", "Shape matching threshold");
-	
+
 	prop = RNA_def_property(srna, "collision_margin", PROP_FLOAT, PROP_NONE);
 	RNA_def_property_float_sdna(prop, NULL, "margin");
 	RNA_def_property_range(prop, 0.01f, 1.0f);
 	RNA_def_property_ui_text(prop, "Margin",
-	                         "Collision margin for soft body. Small value makes the algorithm unstable");
-	
+		"Collision margin for soft body. Small value makes the algorithm unstable");
+
 	prop = RNA_def_property(srna, "weld_threshold", PROP_FLOAT, PROP_DISTANCE);
 	RNA_def_property_float_sdna(prop, NULL, "welding");
 	RNA_def_property_range(prop, 0.0f, 0.01f);
 	RNA_def_property_ui_text(prop, "Welding",
-	                         "Welding threshold: distance between nearby vertices to be considered equal "
-	                         "=> set to 0.0 to disable welding test and speed up scene loading "
-	                         "(ok if the mesh has no duplicates)");
+		"Welding threshold: distance between nearby vertices to be considered equal "
+		"=> set to 0.0 to disable welding test and speed up scene loading "
+		"(ok if the mesh has no duplicates)");
 
+	prop = RNA_def_property(srna, "ksrhr_cl", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kSRHR_CL");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Soft vs Rigid Hardness", "Soft vs rigid hardness");
+
+	prop = RNA_def_property(srna, "kskhr_cl", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kSKHR_CL");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Soft vs Kinetic Hardness", "Soft vs kinetic hardness");
+
+	prop = RNA_def_property(srna, "ksshr_cl", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kSSHR_CL");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Soft vs Soft Hardness", "Soft vs soft hardness");
+
+	prop = RNA_def_property(srna, "ksr_split_cl", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kSR_SPLT_CL");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Rigid Impulse Split", "Rigid impulse split");
+
+	prop = RNA_def_property(srna, "ksk_split_cl", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kSK_SPLT_CL");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Kinetic Impulse Split", "Kinetic impulse split");
+
+	prop = RNA_def_property(srna, "kss_split_cl", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kSS_SPLT_CL");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Soft Impulse Split", "Soft impulse split");
+
+	prop = RNA_def_property(srna, "kvcf", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kVCF");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Velocity Correction Factor", "Velocity correction factor");
+
+	prop = RNA_def_property(srna, "kdp", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kDP");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Damping Coefficient", "Damping coefficient");
+
+	prop = RNA_def_property(srna, "kdg", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kDG");
+	RNA_def_property_range(prop, 0.0f, 1000.0f);
+	RNA_def_property_ui_text(prop, "Drag Coeffient", "Drag coeffient");
+
+	prop = RNA_def_property(srna, "klf", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kLF");
+	RNA_def_property_range(prop, 0.0f, 1000.0f);
+	RNA_def_property_ui_text(prop, "Lift Coefficient", "Lift coefficient");
+
+	prop = RNA_def_property(srna, "kpr", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kPR");
+	RNA_def_property_range(prop, -1000.0f, 1000.0f);
+	RNA_def_property_ui_text(prop, "Pressure Coefficient", "Pressure coefficient");
+
+	prop = RNA_def_property(srna, "kvc", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kVC");
+	RNA_def_property_range(prop, 0.0f, 1000.0f);
+	RNA_def_property_ui_text(prop, "Volume Conservation Coefficient", "Volume conservation coefficient");
+
+	prop = RNA_def_property(srna, "kchr", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kCHR");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Rigid Contacts Hardness", "Rigid contacts hardness");
+
+	prop = RNA_def_property(srna, "kkhr", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kKHR");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Kinetic Contacts Hardness", "Kinetic contacts hardness");
+
+	prop = RNA_def_property(srna, "kshr", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kSHR");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Soft Contacts Hardness", "Soft contacts hardness");
+
+	prop = RNA_def_property(srna, "kahr", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_float_sdna(prop, NULL, "kAHR");
+	RNA_def_property_range(prop, 0.0f, 1.0f);
+	RNA_def_property_ui_text(prop, "Anchors Hardness", "Anchors hardness");
 	/* Integers */
-	
-	prop = RNA_def_property(srna, "location_iterations", PROP_INT, PROP_NONE);
+
+	prop = RNA_def_property(srna, "position_solver_iterations", PROP_INT, PROP_NONE);
 	RNA_def_property_int_sdna(prop, NULL, "piterations");
-	RNA_def_property_range(prop, 0, 10);
-	RNA_def_property_ui_text(prop, "Position Iterations", "Position solver iterations");
-	
+	RNA_def_property_range(prop, 1, 1000);
+	RNA_def_property_ui_text(prop, "Position Solver Iterations", "Position solver iterations");
+
+	prop = RNA_def_property(srna, "velocity_solver_iterations", PROP_INT, PROP_NONE);
+	RNA_def_property_int_sdna(prop, NULL, "viterations");
+	RNA_def_property_range(prop, 0, 1000);
+	RNA_def_property_ui_text(prop, "Velocity Solver Iterations", "Position solver iterations");
+
+	prop = RNA_def_property(srna, "drift_solver_iterations", PROP_INT, PROP_NONE);
+	RNA_def_property_int_sdna(prop, NULL, "diterations");
+	RNA_def_property_range(prop, 0, 1000);
+	RNA_def_property_ui_text(prop, "Drift Solver Iterations", "Drift solver iterations");
+
+	prop = RNA_def_property(srna, "cluster_solver_iterations", PROP_INT, PROP_NONE);
+	RNA_def_property_int_sdna(prop, NULL, "citerations");
+	RNA_def_property_range(prop, 1, 1000);
+	RNA_def_property_ui_text(prop, "Cluster Solver Iterations", "Cluster solver iterations");
+
 	prop = RNA_def_property(srna, "cluster_iterations", PROP_INT, PROP_NONE);
 	RNA_def_property_int_sdna(prop, NULL, "numclusteriterations");
-	RNA_def_property_range(prop, 1, 128);
+	RNA_def_property_range(prop, 1, 1000);
 	RNA_def_property_ui_text(prop, "Cluster Iterations", "Number of cluster iterations");
-	
+
 	/* Booleans */
-	
+
 	prop = RNA_def_property(srna, "use_shape_match", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "flag", OB_BSB_SHAPE_MATCHING);
 	RNA_def_property_ui_text(prop, "Shape Match", "Enable soft body shape matching goal");
-	
+
 	prop = RNA_def_property(srna, "use_bending_constraints", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "flag", OB_BSB_BENDING_CONSTRAINTS);
 	RNA_def_property_ui_text(prop, "Bending Const", "Enable bending constraints");
-	
+
 	prop = RNA_def_property(srna, "use_cluster_rigid_to_softbody", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "collisionflags", OB_BSB_COL_CL_RS);
 	RNA_def_property_ui_text(prop, "Rigid to Soft Body", "Enable cluster collision between soft and rigid body");
-	
+
 	prop = RNA_def_property(srna, "use_cluster_soft_to_softbody", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_sdna(prop, NULL, "collisionflags", OB_BSB_COL_CL_SS);
 	RNA_def_property_ui_text(prop, "Soft to Soft Body", "Enable cluster collision between soft and soft body");


### PR DESCRIPTION
This restores upbge physics tab UI now available in eevee physics panel

But this doesn't fix the collision_bountype issue


Note that there is an issue in UPBGE UI I think in softbody panel related to bending_distance